### PR TITLE
fix: fixed upload of remote files to local storage

### DIFF
--- a/aidial_adapter_dial/app.py
+++ b/aidial_adapter_dial/app.py
@@ -96,6 +96,8 @@ class AzureClient(BaseModel):
                 message=f"The {UPSTREAM_ENDPOINT_HEADER!r} request header is missing",
             )
 
+        # NOTE: it's not really necessary for the endpoint to point to the same deployment id.
+        # Here we just follow the convention used in OpenAI adapter.
         endpoint_suffix = f"/{deployment_id}/{endpoint_name}"
         if not upstream_endpoint.endswith(endpoint_suffix):
             raise HTTPException(

--- a/aidial_adapter_dial/app.py
+++ b/aidial_adapter_dial/app.py
@@ -6,7 +6,7 @@ from aidial_sdk.telemetry.init import init_telemetry
 from aidial_sdk.telemetry.types import TelemetryConfig
 from fastapi import FastAPI, Request
 from fastapi.responses import StreamingResponse
-from openai import AsyncAzureOpenAI, AsyncStream, BaseModel, Timeout
+from openai import AsyncAzureOpenAI, AsyncStream, BaseModel
 from openai.types import CreateEmbeddingResponse
 from openai.types.chat.chat_completion import ChatCompletion
 from openai.types.chat.chat_completion_chunk import ChatCompletionChunk
@@ -41,8 +41,6 @@ UPSTREAM_KEY_HEADER = "X-UPSTREAM-KEY"
 UPSTREAM_ENDPOINT_HEADER = "X-UPSTREAM-ENDPOINT"
 
 LOCAL_DIAL_URL = get_env("DIAL_URL")
-
-DEFAULT_TIMEOUT = Timeout(600, connect=10)
 
 
 def get_hostname(url: str) -> str:

--- a/aidial_adapter_dial/transformer.py
+++ b/aidial_adapter_dial/transformer.py
@@ -1,5 +1,6 @@
 import logging
-from typing import Self
+import re
+from typing import Any, Callable, Coroutine, Self
 
 import aiohttp
 from pydantic import BaseModel
@@ -12,11 +13,11 @@ log = logging.getLogger(__name__)
 
 class AttachmentTransformer(BaseModel):
     local_storage: FileStorage
-    local_bucket: str
+    local_user_bucket: str
     local_app_data: str
 
     remote_storage: FileStorage
-    remote_bucket: str
+    remote_user_bucket: str
 
     @classmethod
     async def create(
@@ -30,81 +31,70 @@ class AttachmentTransformer(BaseModel):
                 raise ValueError(
                     "The local appdata bucket is expected to be set"
                 )
-            local_bucket = AppData.parse(local_appdata).user_bucket
+            local_user_bucket = AppData.parse(local_appdata).user_bucket
 
             remote = await remote_storage.get_bucket(session)
 
         return cls(
             remote_storage=remote_storage,
-            remote_bucket=remote["bucket"],
+            remote_user_bucket=remote["bucket"],
             local_storage=local_storage,
-            local_bucket=local_bucket,
+            local_user_bucket=local_user_bucket,
             local_app_data=local_appdata,
         )
 
     async def get_remote_url(self, local_url: str) -> str:
         """
-        local_url:
-            - files/LOCAL_BUCKET/PATH
-        remote_url:
-            - files/REMOTE_BUCKET/LOCAL_BUCKET/PATH
+        user/app files:
+            < files/LOCAL_USER_BUCKET/PATH
+            > files/REMOTE_USER_BUCKET/LOCAL_USER_BUCKET/PATH
         """
 
-        local_bucket = self.local_bucket
-        remote_bucket = self.remote_bucket
-
-        if not local_url.startswith(f"files/{local_bucket}/"):
+        if not local_url.startswith(f"files/{self.local_user_bucket}/"):
             raise ValueError(f"Unexpected local URL: {local_url!r}")
 
-        return f"files/{remote_bucket}/{local_url.removeprefix('files/')}"
+        return f"files/{self.remote_user_bucket}/{local_url.removeprefix('files/')}"
 
-    async def get_local_url(
-        self, remote_url: str, session: aiohttp.ClientSession
-    ) -> str:
+    async def get_local_url(self, remote_url: str) -> str:
         """
-        remote_url (prefixed by files/REMOTE_BUCKET):
-            original:
-                - /PATH
-            reiterated:
-                - /LOCAL_BUCKET/PATH
-        local_url (try with files/LOCAL_BUCKET/, otherwise with files/LOCAL_BUCKET/appdata/THIS_APP_NAME/):
-            original:
-                - /PATH
-            reiterated:
-                - /PATH
+        user/app files uploaded from local to remote earlier (reverse of get_remote_url):
+            < files/REMOTE_USER_BUCKET/LOCAL_USER_BUCKET/PATH
+            > files/LOCAL_USER_BUCKET/PATH
+
+        created by remote (user):
+            < files/REMOTE_USER_BUCKET/appdata/REMOTE_APP_NAME/PATH
+            > files/LOCAL_USER_BUCKET/appdata/LOCAL_APP_NAME/PATH
+
+        created by remote (app):
+            < files/REMOTE_APP_BUCKET/PATH
+            > This means an application has a bug in it.
+                We reject such URLs right away since there is no way
+                to read an application file by a user.
         """
 
-        remote_bucket = self.remote_bucket
+        if not remote_url.startswith(f"files/{self.remote_user_bucket}/"):
+            raise ValueError(
+                f"The remote file ({remote_url!r}) is expected "
+                f"to be uploaded to the remote user bucket ({self.remote_user_bucket!r})"
+            )
 
-        if not remote_url.startswith(f"files/{remote_bucket}/"):
-            raise ValueError(f"Unexpected remote URL: {remote_url!r}")
-
-        remote_url = remote_url.removeprefix(f"files/{remote_bucket}/")
-        remote_url = remote_url.removeprefix(f"{self.local_bucket}/")
-
-        local_url = f"files/{self.local_bucket}/{remote_url}"
-        if await self.local_storage.is_accessible(local_url, session):
-            return local_url
-
-        local_url = f"files/{self.local_app_data}/{remote_url}"
-        if await self.local_storage.is_accessible(local_url, session):
-            return local_url
-
-        raise ValueError(
-            f"Can't find the local URL for the remote URL: {remote_url!r}"
+        remote_path = remote_url.removeprefix(
+            f"files/{self.remote_user_bucket}/"
         )
 
-    async def upload_and_download_file(
-        self,
-        src_storage: FileStorage,
-        src_url: str,
-        dest_storage: FileStorage,
-        dest_url: str,
-        content_type: str | None,
-        session: aiohttp.ClientSession,
-    ):
-        content = await src_storage.download(src_url, session)
-        await dest_storage.upload(dest_url, content_type, content, session)
+        if remote_path.startswith(f"{self.local_user_bucket}/"):
+            path = remote_path.removeprefix(f"{self.local_user_bucket}/")
+            return f"files/{self.local_user_bucket}/{path}"
+        else:
+            regex = r"appdata/([^/]+)/(.+)"
+            match = re.match(regex, remote_path)
+            if match is None:
+                raise ValueError(
+                    f"The remote file ({remote_url!r}) is expected to be uploaded to a remote appdata path"
+                )
+            _remote_app_name, path = match.groups()
+
+            return f"files/{self.local_app_data}/{path}"
 
     async def modify_request_attachment(self, attachment: dict) -> None:
         if "url" not in attachment:
@@ -117,15 +107,13 @@ class AttachmentTransformer(BaseModel):
         remote_url = await self.get_remote_url(local_url)
         content_type = attachment.get("type")
 
-        async with aiohttp.ClientSession() as session:
-            await self.upload_and_download_file(
-                self.local_storage,
-                local_url,
-                self.remote_storage,
-                remote_url,
-                content_type,
-                session,
-            )
+        await download_and_upload_file(
+            self.local_storage,
+            local_url,
+            self.remote_storage,
+            remote_url,
+            content_type,
+        )
 
         attachment["url"] = remote_url
 
@@ -141,42 +129,28 @@ class AttachmentTransformer(BaseModel):
         if remote_url is None:
             return None
 
-        async with aiohttp.ClientSession() as session:
-            local_url = await self.get_local_url(remote_url, session)
-            content_type = attachment.get("type")
+        local_url = await self.get_local_url(remote_url)
+        content_type = attachment.get("type")
 
-            await self.upload_and_download_file(
-                self.remote_storage,
-                remote_url,
-                self.local_storage,
-                local_url,
-                content_type,
-                session,
-            )
-            attachment["url"] = local_url
+        await download_and_upload_file(
+            self.remote_storage,
+            remote_url,
+            self.local_storage,
+            local_url,
+            content_type,
+        )
+        attachment["url"] = local_url
 
-            log.debug(
-                f"uploaded from remote to local: from {remote_url!r} to {local_url!r}"
-            )
+        log.debug(
+            f"uploaded from remote to local: from {remote_url!r} to {local_url!r}"
+        )
 
     async def modify_request(self, request: dict) -> dict:
         if "messages" in request:
             messages = request["messages"]
             for message in messages:
-                await self.modify_message(
-                    message, self.modify_request_attachment
-                )
+                await modify_message(message, self.modify_request_attachment)
         return request
-
-    async def modify_message(self, message: dict, modify_attachment) -> None:
-        cc = message.get("custom_content")
-        if cc is None:
-            return
-        attachments = cc.get("attachments")
-        if attachments is None:
-            return
-        for attachment in attachments:
-            await modify_attachment(attachment)
 
     async def modify_response_chunk(self, response: dict) -> dict:
         choices = response.get("choices")
@@ -185,7 +159,7 @@ class AttachmentTransformer(BaseModel):
 
         for choice in choices:
             if "delta" in choice:
-                await self.modify_message(
+                await modify_message(
                     choice["delta"], self.modify_response_attachment
                 )
 
@@ -198,8 +172,34 @@ class AttachmentTransformer(BaseModel):
 
         for choice in choices:
             if "message" in choice:
-                await self.modify_message(
+                await modify_message(
                     choice["message"], self.modify_response_attachment
                 )
 
         return response
+
+
+async def download_and_upload_file(
+    src_storage: FileStorage,
+    src_url: str,
+    dest_storage: FileStorage,
+    dest_url: str,
+    content_type: str | None,
+):
+    async with aiohttp.ClientSession() as session:
+        content = await src_storage.download(src_url, session)
+        await dest_storage.upload(dest_url, content_type, content, session)
+
+
+async def modify_message(
+    message: dict,
+    modify_attachment: Callable[[dict], Coroutine[Any, Any, None]],
+) -> None:
+    cc = message.get("custom_content")
+    if cc is None:
+        return
+    attachments = cc.get("attachments")
+    if attachments is None:
+        return
+    for attachment in attachments:
+        await modify_attachment(attachment)

--- a/docker-compose/generate-config/app.py
+++ b/docker-compose/generate-config/app.py
@@ -217,7 +217,7 @@ def process_data(
 
         model = {
             "type": model_type,
-            "displayName": item.display_name,
+            "displayName": f"{item.display_name} (Adapter)",
             "displayVersion": item.display_version,
             "description": item.description,
             "tokenizerModel": item.tokenizer_model,
@@ -278,9 +278,12 @@ def process_data(
             },
         }
 
-        # Note that even applications are declared as models,
-        # because only models have "upstreams" property.
-        config.add_model(item.id, model)
+        # Note that
+        # * even applications are declared as models,
+        #   because only models have "upstreams" property.
+        # * the local deployment id is different from the remote deployment id
+        #   to highlight that the two are not required to be the same.
+        config.add_model(f"{item.id}-adapter", model)
 
 
 if __name__ == "__main__":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,6 +73,7 @@ exclude = '''
   | \.venv
   | \.nox
   | \.__pycache__
+  | docker-compose\/local\/core-data
 )/
 '''
 


### PR DESCRIPTION
Previously the upload was failing in case when local deployment id didn't match the remote deployment id.