### PR TITLE
fix: supported request without model field

### DIFF
--- a/aidial_adapter_dial/utils/reflection.py
+++ b/aidial_adapter_dial/utils/reflection.py
@@ -25,6 +25,7 @@ async def call_with_extra_body(
         )
 
     arg["extra_body"] = arg.get("extra_body") or {}
+    arg["model"] = arg.get("model")  # model arg is required in AsyncAzureOpenAI
 
     for extra_arg in extra_args:
         arg["extra_body"][extra_arg] = arg[extra_arg]


### PR DESCRIPTION
Same fix as https://github.com/epam/ai-dial-interceptors-sdk/pull/4

The bug manifests itself when a request without a `model` field is sent to the DIAL adapter.
It returns the following error due to strict validation in `openai` library:

```json
{
  "detail": {
    "error": {
      "message": "Missing required arguments; Expected either ('messages' and 'model') or ('messages', 'model' and 'stream') arguments to be given",
      "type": "internal_server_error"
    }
  }
}
```