### PR TITLE
fix: removed content-encoding header to avoid decoding errors

### DIFF
--- a/aidial_adapter_dial/utils/exceptions.py
+++ b/aidial_adapter_dial/utils/exceptions.py
@@ -69,8 +69,19 @@ def to_dial_exception(e: Exception) -> HTTPException | FastAPIException:
         r = e.response
         headers = r.headers
 
+        # The original content length may have changed
+        # due to the response modification in the adapter.
         if "Content-Length" in headers:
             del headers["Content-Length"]
+
+        # httpx library (used by openai) automatically sets
+        # "Accept-Encoding:gzip,deflate" header in requests to the upstream.
+        # Therefore, we may receive from the upstream gzip-encoded
+        # response along with "Content-Encoding:gzip" header.
+        # We either need to encode the response, or
+        # remove the "Content-Encoding" header.
+        if "Content-Encoding" in headers:
+            del headers["Content-Encoding"]
 
         return FastAPIException(
             detail=r.text,


### PR DESCRIPTION
`httpx` library used by `openai` is sending `Accept-Encoding: gzip, deflate` by default: 

https://github.com/encode/httpx/blob/7b19cd5f4b749064c6452892a5e58a3758da1d1b/httpx/_client.py#L305-L315

This results in responses from the upstream which are encoded via `gzip` and having `Content-Encoding: gzip` header.

In the adapter, all the responses from upstream are decoded, modified and sent to the user as plain text, without any encoding.

Therefore, we must either do the encoding when needed or return the response without `Content-Encoding: gzip` header pretending that the server doesn't support encoding.

Given that the latter is so much easier to implement and that the adapter only proxies the response headers for errors, it was chosen as a solution.

### How to reproduce the bug

Send an erroneous request to the dial-adapter deployment:

```python
    response = client.chat.completions.create(
        model=MODEL,
        messages=[{"content": "2+3=?", "role": "users"}],
        stream=True,
    )
    for chunk in response:
        print(chunk)
```

Observe the error message:

```
  File ".venv/lib/python3.11/site-packages/httpx/_models.py", line 805, in read
    self._content = b"".join(self.iter_bytes())
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File ".venv/lib/python3.11/site-packages/httpx/_models.py", line 824, in iter_bytes
    decoded = decoder.decode(raw_bytes)
              ^^^^^^^^^^^^^^^^^^^^^^^^^
  File ".venv/lib/python3.11/site-packages/httpx/_decoders.py", line 78, in decode
    raise DecodingError(str(exc)) from exc
httpx.DecodingError: Error -3 while decompressing data: incorrect header check
```

resulted from an attempt to decode plain-text content using gzip algorithm since `Content-Encoding` header is set to `gzip` in the response.