### PR TITLE
chore: revert: bumps version of sqlite-libs from 3.48.0-r0 to 3.49.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,12 +16,10 @@ RUN poetry install --no-interaction --no-ansi --no-cache --only main
 
 FROM python:3.11-alpine as server
 
-RUN apk update && apk upgrade --no-cache libcrypto3 libssl3 \
-    # fix CVE-2023-52425
-    && apk upgrade --no-cache libexpat \
-    # fix CVE-2025-29087
-    && apk add --no-cache sqlite-libs==3.49.1 --force
+RUN apk update && apk upgrade --no-cache libcrypto3 libssl3
 
+# fix CVE-2023-52425
+RUN apk upgrade --no-cache libexpat
 # fix CVE-2024-6345
 RUN pip install "setuptools==70.0.0"
 


### PR DESCRIPTION
The fix is analogous to https://github.com/epam/ai-dial-adapter-openai/pull/218