### PR TITLE
chore: remove deprecated addons feature from generate-config script

### DIFF
--- a/docker-compose/generate-config/app.py
+++ b/docker-compose/generate-config/app.py
@@ -1,6 +1,7 @@
 import os
 import re
 import sys
+from pathlib import Path
 from typing import Any, Dict, List, Literal, Optional
 from urllib.parse import urlparse, urlunparse
 
@@ -59,7 +60,6 @@ class Features(BaseModel):
     accessible_by_per_request_key: bool
     content_parts: bool
     temperature: bool
-    addons: bool
 
     def to_conf(self, endpoint_base: str) -> dict:
         return {
@@ -84,7 +84,6 @@ class Features(BaseModel):
             "accessibleByPerRequestKey": self.accessible_by_per_request_key,
             "contentPartsSupported": self.content_parts,
             "temperatureSupported": self.temperature,
-            "addonsSupported": self.addons,
         }
 
 
@@ -139,7 +138,7 @@ def modify_url(
     return urlunparse(modified_url)
 
 
-load_dotenv()
+load_dotenv(Path(__file__).parent.parent / "local" / ".env")
 REMOTE_DIAL_URL = get_env("REMOTE_DIAL_URL")
 REMOTE_DIAL_API_KEY = get_env("REMOTE_DIAL_API_KEY")
 
@@ -220,7 +219,6 @@ def main(
                         accessible_by_per_request_key=True,
                         content_parts=True,
                         temperature=True,
-                        addons=True,
                     ).to_conf(endpoint_base),
                 },
             )

--- a/docker-compose/local/README.md
+++ b/docker-compose/local/README.md
@@ -8,7 +8,7 @@
 
 2. Access to the **remote** DIAL Core server is configured by the env vars `$REMOTE_DIAL_URL` and `$REMOTE_DIAL_API_KEY`. Create `.env` file with the following content:
 
-    ```init
+    ```ini
     REMOTE_DIAL_URL="url-to-dial-core"
     REMOTE_DIAL_API_KEY="dial-api-key"
     ```

--- a/docker-compose/local/README.md
+++ b/docker-compose/local/README.md
@@ -6,12 +6,17 @@
     cd docker-compose/local
     ```
 
-2. Access to the **remote** DIAL Core server is specified by env vars `$REMOTE_DIAL_URL` and `$REMOTE_DIAL_API_KEY`.
+2. Access to the **remote** DIAL Core server is configured by the env vars `$REMOTE_DIAL_URL` and `$REMOTE_DIAL_API_KEY`. Create `.env` file with the following content:
 
-    Run the following command to generate **local** DIAL Core config `core/config.json` based on the listing from the **remote** DIAL Core:
+    ```init
+    REMOTE_DIAL_URL="url-to-dial-core"
+    REMOTE_DIAL_API_KEY="dial-api-key"
+    ```
+
+3. Run the following command to generate **local** DIAL Core config `core/config.json` based on the listing from the **remote** DIAL Core:
 
     ```sh
-    REMOTE_DIAL_URL="url" REMOTE_DIAL_API_KEY="key" ./generate_config_from_listing.sh
+    ./generate_config_from_listing.sh
     ```
 
     This script requires installed Python.
@@ -19,14 +24,14 @@
     Use a simple config template, if you are experiencing issues running the script above:
 
     ```sh
-    REMOTE_DIAL_URL="url" REMOTE_DIAL_API_KEY="key" ./generate_config_from_template.sh
+    ./generate_config_from_template.sh
     ```
 
-3. The script also adds definition of a sample locally hosted application to the DIAL config. This allows to call an application served at `http://localhost:5005/openai/deployments/app/chat/completions` from the local DIAL chat.
+4. The script also adds definition of a sample locally hosted application to the DIAL config. This allows to call an application served at `http://localhost:5005/openai/deployments/app/chat/completions` from the local DIAL chat.
 
-4. Modify the generated `core/config.json` as you see fit: add required models and applications hosted by the remote DIAL server, configure locally hosted applications.
+5. Modify the generated `core/config.json` as you see fit: add required models and applications hosted by the remote DIAL server, configure locally hosted applications.
 
-5. Finally, run the local DIAL Core and DIAL Chat via:
+6. Finally, run the local DIAL Core and DIAL Chat via:
 
     ```sh
     docker compose up --abort-on-container-exit
@@ -38,10 +43,11 @@
     UID=$(id -u) docker compose up --abort-on-container-exit
     ```
 
-6. Open local DIAL Chat at [http://localhost:3000](http://localhost:3000)
+7. Open local DIAL Chat at [http://localhost:3000](http://localhost:3000)
 
 > [!NOTE]
 > The docker-compose file uses `latest` tag for the DIAL components. Once the images are pulled from the repository, the Docker won't pull it again and use the cached image. To update the images, run the following before starting the containers:
+>
 > ```sh
 > docker compose pull
 > ```


### PR DESCRIPTION
The addons and assistants have been removed from DIAL recently.