### PR TITLE
feat: support chat completion feature endpoints

### DIFF
--- a/aidial_adapter_dial/app.py
+++ b/aidial_adapter_dial/app.py
@@ -148,7 +148,7 @@ for endpoint in ["configuration"]:
 
     @app.get(f"/{endpoint}")
     @app.get("/openai/deployments/{deployment_id:path}/" + endpoint)
-    async def get_endpoint_proxy(request: Request):
+    async def get_endpoint_proxy(request: Request, endpoint=endpoint):
         az_client = await AzureClient.parse(request, "chat/completions")
         return await az_client.client.get(path=endpoint, cast_to=dict)
 
@@ -157,7 +157,7 @@ for endpoint in ["tokenize", "truncate_prompt"]:
 
     @app.post(f"/{endpoint}")
     @app.post("/openai/deployments/{deployment_id:path}/" + endpoint)
-    async def post_endpoint_proxy(request: Request):
+    async def post_endpoint_proxy(request: Request, endpoint=endpoint):
         az_client = await AzureClient.parse(request, "chat/completions")
         body = await request.json()
         return await az_client.client.post(

--- a/aidial_adapter_dial/app.py
+++ b/aidial_adapter_dial/app.py
@@ -1,7 +1,6 @@
 import json
 import logging
 
-import httpx
 from aidial_sdk.exceptions import InvalidRequestError
 from aidial_sdk.telemetry.init import init_telemetry
 from aidial_sdk.telemetry.types import TelemetryConfig
@@ -138,9 +137,7 @@ for endpoint in ["configuration"]:
     @app.get("/openai/deployments/{deployment_id:path}/" + endpoint)
     async def get_endpoint_proxy(request: Request, endpoint=endpoint):
         az_client = await AzureClient.parse(request)
-        return await az_client.dial_client.get(
-            path=endpoint, cast_to=httpx.Response
-        )
+        return await az_client.dial_client.get(path=endpoint, cast_to=object)
 
 
 for endpoint in ["tokenize", "truncate_prompt"]:
@@ -151,7 +148,7 @@ for endpoint in ["tokenize", "truncate_prompt"]:
         body = await request.json()
         az_client = await AzureClient.parse(request)
         return await az_client.dial_client.post(
-            path=endpoint, cast_to=httpx.Response, body=body
+            path=endpoint, cast_to=object, body=body
         )
 
 

--- a/aidial_adapter_dial/app.py
+++ b/aidial_adapter_dial/app.py
@@ -140,6 +140,18 @@ class AzureClient(BaseModel):
         )
 
 
+for endpoint in ["configuration", "tokenize", "truncate_prompt"]:
+
+    @app.post(f"/{endpoint}")
+    @app.post("/openai/deployments/{deployment_id:path}/" + endpoint)
+    async def feature_endpoint_proxy(request: Request):
+        body = await request.json()
+        az_client = await AzureClient.parse(request, endpoint)
+        return await az_client.client.post(
+            path=endpoint, cast_to=dict, body=body
+        )
+
+
 @app.post("/embeddings")
 @app.post("/openai/deployments/{deployment_id:path}/embeddings")
 async def embeddings_proxy(request: Request):

--- a/aidial_adapter_dial/app.py
+++ b/aidial_adapter_dial/app.py
@@ -53,12 +53,11 @@ class AzureClient(BaseModel):
 
     @classmethod
     async def parse(cls, request: Request, endpoint_name: str) -> "AzureClient":
-
-        body = await request.json()
         headers = request.headers.mutablecopy()
         query_params = request.query_params
 
         if is_debug:
+            body = await request.body()
             log.debug(f"request.body: {body}")
             secret_headers = ["api-key", "authorization", UPSTREAM_KEY_HEADER]
             log.debug(
@@ -140,13 +139,22 @@ class AzureClient(BaseModel):
         )
 
 
-for endpoint in ["configuration", "tokenize", "truncate_prompt"]:
+for endpoint in ["configuration"]:
+
+    @app.get(f"/{endpoint}")
+    @app.get("/openai/deployments/{deployment_id:path}/" + endpoint)
+    async def get_endpoint_proxy(request: Request):
+        az_client = await AzureClient.parse(request, endpoint)
+        return await az_client.client.get(path=endpoint, cast_to=dict)
+
+
+for endpoint in ["tokenize", "truncate_prompt"]:
 
     @app.post(f"/{endpoint}")
     @app.post("/openai/deployments/{deployment_id:path}/" + endpoint)
-    async def feature_endpoint_proxy(request: Request):
-        body = await request.json()
+    async def post_endpoint_proxy(request: Request):
         az_client = await AzureClient.parse(request, endpoint)
+        body = await request.json()
         return await az_client.client.post(
             path=endpoint, cast_to=dict, body=body
         )

--- a/aidial_adapter_dial/app.py
+++ b/aidial_adapter_dial/app.py
@@ -1,5 +1,6 @@
 import json
 import logging
+from typing import Literal
 from urllib.parse import urlparse
 
 from aidial_sdk.exceptions import InvalidRequestError
@@ -52,7 +53,11 @@ class AzureClient(BaseModel):
         arbitrary_types_allowed = True
 
     @classmethod
-    async def parse(cls, request: Request, endpoint_name: str) -> "AzureClient":
+    async def parse(
+        cls,
+        request: Request,
+        upstream_endpoint_name: Literal["chat/completions", "embeddings"],
+    ) -> "AzureClient":
         headers = request.headers.mutablecopy()
         query_params = request.query_params
 
@@ -94,7 +99,7 @@ class AzureClient(BaseModel):
 
             remote_dial_api_key = local_dial_api_key
 
-        endpoint_suffix = f"/{endpoint_name}"
+        endpoint_suffix = f"/{upstream_endpoint_name}"
         if not upstream_endpoint.endswith(endpoint_suffix):
             raise InvalidRequestError(
                 f"The {UPSTREAM_ENDPOINT_HEADER!r} request header must end with {endpoint_suffix!r}"
@@ -144,7 +149,7 @@ for endpoint in ["configuration"]:
     @app.get(f"/{endpoint}")
     @app.get("/openai/deployments/{deployment_id:path}/" + endpoint)
     async def get_endpoint_proxy(request: Request):
-        az_client = await AzureClient.parse(request, endpoint)
+        az_client = await AzureClient.parse(request, "chat/completions")
         return await az_client.client.get(path=endpoint, cast_to=dict)
 
 
@@ -153,7 +158,7 @@ for endpoint in ["tokenize", "truncate_prompt"]:
     @app.post(f"/{endpoint}")
     @app.post("/openai/deployments/{deployment_id:path}/" + endpoint)
     async def post_endpoint_proxy(request: Request):
-        az_client = await AzureClient.parse(request, endpoint)
+        az_client = await AzureClient.parse(request, "chat/completions")
         body = await request.json()
         return await az_client.client.post(
             path=endpoint, cast_to=dict, body=body

--- a/aidial_adapter_dial/app.py
+++ b/aidial_adapter_dial/app.py
@@ -1,6 +1,7 @@
 import json
 import logging
 
+import httpx
 from aidial_sdk.exceptions import InvalidRequestError
 from aidial_sdk.telemetry.init import init_telemetry
 from aidial_sdk.telemetry.types import TelemetryConfig
@@ -137,7 +138,9 @@ for endpoint in ["configuration"]:
     @app.get("/openai/deployments/{deployment_id:path}/" + endpoint)
     async def get_endpoint_proxy(request: Request, endpoint=endpoint):
         az_client = await AzureClient.parse(request)
-        return await az_client.dial_client.get(path=endpoint, cast_to=dict)
+        return await az_client.dial_client.get(
+            path=endpoint, cast_to=httpx.Response
+        )
 
 
 for endpoint in ["tokenize", "truncate_prompt"]:
@@ -148,7 +151,7 @@ for endpoint in ["tokenize", "truncate_prompt"]:
         body = await request.json()
         az_client = await AzureClient.parse(request)
         return await az_client.dial_client.post(
-            path=endpoint, cast_to=dict, body=body
+            path=endpoint, cast_to=httpx.Response, body=body
         )
 
 

--- a/aidial_adapter_dial/app.py
+++ b/aidial_adapter_dial/app.py
@@ -1,7 +1,5 @@
 import json
 import logging
-from typing import Literal
-from urllib.parse import urlparse
 
 from aidial_sdk.exceptions import InvalidRequestError
 from aidial_sdk.telemetry.init import init_telemetry
@@ -14,6 +12,7 @@ from openai.types.chat.chat_completion import ChatCompletion
 from openai.types.chat.chat_completion_chunk import ChatCompletionChunk
 
 from aidial_adapter_dial.transformer import AttachmentTransformer
+from aidial_adapter_dial.utils.dial_endpoint import DialEndpoint
 from aidial_adapter_dial.utils.dict import censor_ci_dict
 from aidial_adapter_dial.utils.env import get_env, get_env_list
 from aidial_adapter_dial.utils.exceptions import to_dial_exception
@@ -39,25 +38,16 @@ LOCAL_DIAL_URL = get_env("DIAL_URL")
 HEADERS_TO_PROXY = get_env_list("HEADERS_TO_PROXY", ["Accept"])
 
 
-def get_hostname(url: str) -> str:
-    parsed_url = urlparse(url)
-    hostname = f"{parsed_url.scheme}://{parsed_url.netloc}"
-    return hostname
-
-
 class AzureClient(BaseModel):
     client: AsyncAzureOpenAI
+    dial_client: AsyncAzureOpenAI
     attachment_transformer: AttachmentTransformer
 
     class Config:
         arbitrary_types_allowed = True
 
     @classmethod
-    async def parse(
-        cls,
-        request: Request,
-        upstream_endpoint_name: Literal["chat/completions", "embeddings"],
-    ) -> "AzureClient":
+    async def parse(cls, request: Request) -> "AzureClient":
         headers = request.headers.mutablecopy()
         query_params = request.query_params
 
@@ -80,7 +70,8 @@ class AzureClient(BaseModel):
                 f"The {UPSTREAM_ENDPOINT_HEADER!r} request header is missing"
             )
 
-        remote_dial_url = get_hostname(upstream_endpoint)
+        dial_endpoint = DialEndpoint.parse(upstream_endpoint)
+        remote_dial_url = dial_endpoint.dial_url
         remote_dial_api_key = headers.get(UPSTREAM_KEY_HEADER, None)
 
         if not remote_dial_api_key:
@@ -99,13 +90,6 @@ class AzureClient(BaseModel):
 
             remote_dial_api_key = local_dial_api_key
 
-        endpoint_suffix = f"/{upstream_endpoint_name}"
-        if not upstream_endpoint.endswith(endpoint_suffix):
-            raise InvalidRequestError(
-                f"The {UPSTREAM_ENDPOINT_HEADER!r} request header must end with {endpoint_suffix!r}"
-            )
-        upstream_endpoint = upstream_endpoint.removesuffix(endpoint_suffix)
-
         extra_upstream_headers = {
             key: val
             for key in HEADERS_TO_PROXY
@@ -113,7 +97,7 @@ class AzureClient(BaseModel):
         }
 
         client = AsyncAzureOpenAI(
-            base_url=upstream_endpoint,
+            base_url=dial_endpoint.azure_base_url,
             api_key=remote_dial_api_key,
             # NOTE: defaulting missing api-version to an empty string, because
             # 1. openai library doesn't allow for a missing api-version
@@ -126,6 +110,8 @@ class AzureClient(BaseModel):
             default_headers=extra_upstream_headers,
             http_client=get_http_client(),
         )
+
+        dial_client = client.copy(base_url=dial_endpoint.dial_base_url)
 
         attachment_transformer = await AttachmentTransformer.create(
             local_storage=FileStorage(
@@ -140,6 +126,7 @@ class AzureClient(BaseModel):
 
         return cls(
             client=client,
+            dial_client=dial_client,
             attachment_transformer=attachment_transformer,
         )
 
@@ -149,8 +136,8 @@ for endpoint in ["configuration"]:
     @app.get(f"/{endpoint}")
     @app.get("/openai/deployments/{deployment_id:path}/" + endpoint)
     async def get_endpoint_proxy(request: Request, endpoint=endpoint):
-        az_client = await AzureClient.parse(request, "chat/completions")
-        return await az_client.client.get(path=endpoint, cast_to=dict)
+        az_client = await AzureClient.parse(request)
+        return await az_client.dial_client.get(path=endpoint, cast_to=dict)
 
 
 for endpoint in ["tokenize", "truncate_prompt"]:
@@ -158,9 +145,9 @@ for endpoint in ["tokenize", "truncate_prompt"]:
     @app.post(f"/{endpoint}")
     @app.post("/openai/deployments/{deployment_id:path}/" + endpoint)
     async def post_endpoint_proxy(request: Request, endpoint=endpoint):
-        az_client = await AzureClient.parse(request, "chat/completions")
         body = await request.json()
-        return await az_client.client.post(
+        az_client = await AzureClient.parse(request)
+        return await az_client.dial_client.post(
             path=endpoint, cast_to=dict, body=body
         )
 
@@ -169,20 +156,17 @@ for endpoint in ["tokenize", "truncate_prompt"]:
 @app.post("/openai/deployments/{deployment_id:path}/embeddings")
 async def embeddings_proxy(request: Request):
     body = await request.json()
-    az_client = await AzureClient.parse(request, "embeddings")
-
+    az_client = await AzureClient.parse(request)
     response: CreateEmbeddingResponse = await call_with_extra_body(
         az_client.client.embeddings.create, body
     )
-
     return response.to_dict()
 
 
 @app.post("/chat/completions")
 @app.post("/openai/deployments/{deployment_id:path}/chat/completions")
 async def chat_completions_proxy(request: Request):
-
-    az_client = await AzureClient.parse(request, "chat/completions")
+    az_client = await AzureClient.parse(request)
 
     transformer = az_client.attachment_transformer
 

--- a/aidial_adapter_dial/utils/dial_endpoint.py
+++ b/aidial_adapter_dial/utils/dial_endpoint.py
@@ -1,0 +1,65 @@
+from typing import Literal
+from urllib.parse import urlparse, urlsplit
+
+from aidial_sdk.exceptions import InvalidRequestError
+from openai import BaseModel
+
+
+class DialEndpoint(BaseModel):
+    dial_url: str
+    deployment_id: str
+    type_: Literal["chat", "embedding"]
+
+    @classmethod
+    def parse(cls, url: str) -> "DialEndpoint":
+        orig_url = url
+        dial_url = _get_hostname(url)
+
+        u = urlsplit(url)
+
+        if not u.scheme or not u.netloc:
+            raise InvalidRequestError(
+                f"Upstream endpoint must be an absolute URL: {orig_url!r}"
+            )
+
+        segments = [s for s in u.path.split("/") if s]
+
+        if segments[0:2] != ["openai", "deployments"]:
+            raise InvalidRequestError(
+                f"Cannot parse the upstream endpoint: {orig_url!r}"
+            )
+
+        if segments[-2:] == ["chat", "completions"]:
+            type_: Literal["chat", "embedding"] = "chat"
+            deployment_segments = segments[2:-2]
+        elif segments[-1] == "embeddings":
+            type_ = "embedding"
+            deployment_segments = segments[2:-1]
+        else:
+            raise InvalidRequestError(
+                f"The upstream endpoint {orig_url!r} is expected to end with "
+                f"'/chat/completions' or '/embeddings'."
+            )
+
+        if not deployment_segments:
+            raise InvalidRequestError(
+                f"Missing deployment_id in upstream endpoint: {orig_url!r}"
+            )
+
+        deployment_id = "/".join(deployment_segments)
+
+        return cls(type_=type_, dial_url=dial_url, deployment_id=deployment_id)
+
+    @property
+    def azure_base_url(self) -> str:
+        return f"{self.dial_url}/openai/deployments/{self.deployment_id}"
+
+    @property
+    def dial_base_url(self) -> str:
+        return f"{self.dial_url}/v1/deployments/{self.deployment_id}"
+
+
+def _get_hostname(url: str) -> str:
+    parsed_url = urlparse(url)
+    hostname = f"{parsed_url.scheme}://{parsed_url.netloc}"
+    return hostname

--- a/aidial_adapter_dial/utils/dial_endpoint.py
+++ b/aidial_adapter_dial/utils/dial_endpoint.py
@@ -1,5 +1,5 @@
 from typing import Literal
-from urllib.parse import urlparse, urlsplit
+from urllib.parse import urlsplit
 
 from aidial_sdk.exceptions import InvalidRequestError
 from openai import BaseModel
@@ -13,15 +13,14 @@ class DialEndpoint(BaseModel):
     @classmethod
     def parse(cls, url: str) -> "DialEndpoint":
         orig_url = url
-        dial_url = _get_hostname(url)
 
         u = urlsplit(url)
-
         if not u.scheme or not u.netloc:
             raise InvalidRequestError(
                 f"Upstream endpoint must be an absolute URL: {orig_url!r}"
             )
 
+        dial_url = f"{u.scheme}://{u.netloc}"
         segments = [s for s in u.path.split("/") if s]
 
         if segments[0:2] != ["openai", "deployments"]:
@@ -57,9 +56,3 @@ class DialEndpoint(BaseModel):
     @property
     def dial_base_url(self) -> str:
         return f"{self.dial_url}/v1/deployments/{self.deployment_id}"
-
-
-def _get_hostname(url: str) -> str:
-    parsed_url = urlparse(url)
-    hostname = f"{parsed_url.scheme}://{parsed_url.netloc}"
-    return hostname

--- a/aidial_adapter_dial/utils/dial_endpoint.py
+++ b/aidial_adapter_dial/utils/dial_endpoint.py
@@ -12,20 +12,18 @@ class DialEndpoint(BaseModel):
 
     @classmethod
     def parse(cls, url: str) -> "DialEndpoint":
-        orig_url = url
-
-        u = urlsplit(url)
-        if not u.scheme or not u.netloc:
+        parsed_url = urlsplit(url)
+        if not parsed_url.scheme or not parsed_url.netloc:
             raise InvalidRequestError(
-                f"Upstream endpoint must be an absolute URL: {orig_url!r}"
+                f"Upstream endpoint must be an absolute URL: {url!r}"
             )
 
-        dial_url = f"{u.scheme}://{u.netloc}"
-        segments = [s for s in u.path.split("/") if s]
+        dial_url = f"{parsed_url.scheme}://{parsed_url.netloc}"
+        segments = [s for s in parsed_url.path.split("/") if s]
 
         if segments[0:2] != ["openai", "deployments"]:
             raise InvalidRequestError(
-                f"Cannot parse the upstream endpoint: {orig_url!r}"
+                f"Cannot parse the upstream endpoint: {url!r}"
             )
 
         if segments[-2:] == ["chat", "completions"]:
@@ -36,13 +34,13 @@ class DialEndpoint(BaseModel):
             deployment_segments = segments[2:-1]
         else:
             raise InvalidRequestError(
-                f"The upstream endpoint {orig_url!r} is expected to end with "
+                f"The upstream endpoint {url!r} is expected to end with "
                 f"'/chat/completions' or '/embeddings'."
             )
 
         if not deployment_segments:
             raise InvalidRequestError(
-                f"Missing deployment_id in upstream endpoint: {orig_url!r}"
+                f"Missing deployment_id in upstream endpoint: {url!r}"
             )
 
         deployment_id = "/".join(deployment_segments)


### PR DESCRIPTION
Resolves #39 

**Limitations**: `truncate_prompt` and `tokenize` handlers do not transform their request body; that is, references to local DIAL storage aren't translated to references to remote DIAL storage. Postponed for another PR.