### PR TITLE
fix: block non-public addresses when downloading attachments

### DIFF
--- a/aidial_adapter_dial/utils/storage.py
+++ b/aidial_adapter_dial/utils/storage.py
@@ -168,6 +168,8 @@ class FileStorage(BaseModel):
     async def download(self, url: str, session: aiohttp.ClientSession) -> bytes:
         log.debug(f"downloading file {url!r}")
 
+        if self.to_dial_url(url) is None:
+            raise ValueError(f"URL isn't DIAL url: {url!r}")
         url = self.to_abs_url(url)
 
         # DIAL Core is trusted infrastructure: when the URL resolves to its

--- a/aidial_adapter_dial/utils/storage.py
+++ b/aidial_adapter_dial/utils/storage.py
@@ -8,6 +8,11 @@ import aiohttp
 from pydantic import BaseModel
 from typing_extensions import TypedDict
 
+from aidial_adapter_dial.utils.url import (
+    download_public_file,
+    has_same_origin,
+)
+
 log = logging.getLogger(__name__)
 
 
@@ -163,13 +168,24 @@ class FileStorage(BaseModel):
     async def download(self, url: str, session: aiohttp.ClientSession) -> bytes:
         log.debug(f"downloading file {url!r}")
 
-        if self.to_dial_url(url) is None:
-            raise ValueError(f"URL isn't DIAL url: {url!r}")
         url = self.to_abs_url(url)
 
-        async with (
-            aiohttp.ClientSession() as session,
-            session.get(url, headers=self.headers) as response,
-        ):
-            response.raise_for_status()
-            return await response.read()
+        # DIAL Core is trusted infrastructure: when the URL resolves to its
+        # origin, fetch it directly with the api-key. The storage may
+        # legitimately live on a private address, so SSRF checks would be
+        # counterproductive here. The origin is matched by scheme/host/port,
+        # never by string prefix: a URL like
+        # ``http://<dial_url>@169.254.169.254`` shares the base-URL prefix yet
+        # resolves to a different, internal host - a prefix check would treat
+        # it as trusted, skip SSRF validation and leak the api-key.
+        if has_same_origin(url, self.dial_url):
+            async with (
+                aiohttp.ClientSession() as session,
+                session.get(url, headers=self.headers) as response,
+            ):
+                response.raise_for_status()
+                return await response.read()
+
+        # Any other (attacker-controllable) URL is validated against SSRF and
+        # never receives credentials.
+        return await download_public_file(url)

--- a/aidial_adapter_dial/utils/storage.py
+++ b/aidial_adapter_dial/utils/storage.py
@@ -8,10 +8,7 @@ import aiohttp
 from pydantic import BaseModel
 from typing_extensions import TypedDict
 
-from aidial_adapter_dial.utils.url import (
-    download_public_file,
-    has_same_origin,
-)
+from aidial_adapter_dial.utils.url import has_same_origin
 
 log = logging.getLogger(__name__)
 
@@ -168,26 +165,22 @@ class FileStorage(BaseModel):
     async def download(self, url: str, session: aiohttp.ClientSession) -> bytes:
         log.debug(f"downloading file {url!r}")
 
-        if self.to_dial_url(url) is None:
-            raise ValueError(f"URL isn't DIAL url: {url!r}")
         url = self.to_abs_url(url)
 
-        # DIAL Core is trusted infrastructure: when the URL resolves to its
-        # origin, fetch it directly with the api-key. The storage may
-        # legitimately live on a private address, so SSRF checks would be
-        # counterproductive here. The origin is matched by scheme/host/port,
-        # never by string prefix: a URL like
-        # ``http://<dial_url>@169.254.169.254`` shares the base-URL prefix yet
+        # The adapter only ever downloads files from its own DIAL storage; any
+        # other URL is left untouched and passed through to the remote DIAL,
+        # never fetched here. The api-key is therefore only ever sent to the
+        # DIAL origin. Trust is decided by origin (scheme/host/port), never by
+        # string prefix: a URL like ``http://<dial_url>@169.254.169.254`` or
+        # ``http://<dial_url>.attacker.example`` shares the base-URL prefix yet
         # resolves to a different, internal host - a prefix check would treat
-        # it as trusted, skip SSRF validation and leak the api-key.
-        if has_same_origin(url, self.dial_url):
-            async with (
-                aiohttp.ClientSession() as session,
-                session.get(url, headers=self.headers) as response,
-            ):
-                response.raise_for_status()
-                return await response.read()
+        # it as a DIAL URL and leak the api-key to an attacker-controlled host.
+        if not has_same_origin(url, self.dial_url):
+            raise ValueError(f"URL isn't DIAL url: {url!r}")
 
-        # Any other (attacker-controllable) URL is validated against SSRF and
-        # never receives credentials.
-        return await download_public_file(url)
+        async with (
+            aiohttp.ClientSession() as session,
+            session.get(url, headers=self.headers) as response,
+        ):
+            response.raise_for_status()
+            return await response.read()

--- a/aidial_adapter_dial/utils/url.py
+++ b/aidial_adapter_dial/utils/url.py
@@ -1,22 +1,6 @@
-import asyncio
-import ipaddress
-import socket
-from urllib.parse import urljoin, urlparse, urlunparse
-
-import aiohttp
-from aidial_sdk.exceptions import InvalidRequestError
+from urllib.parse import urlparse, urlunparse
 
 _DEFAULT_PORTS = {"http": 80, "https": 443}
-
-# Only regular web schemes are allowed. Everything else (e.g. ``file``,
-# ``ftp``, ``gopher``) could be abused to reach local files or internal
-# services.
-_ALLOWED_SCHEMES = frozenset({"http", "https"})
-
-# Redirects are followed manually so that every hop can be re-validated
-# against SSRF, otherwise a public URL could redirect to an internal address.
-_MAX_REDIRECTS = 5
-_REDIRECT_STATUSES = frozenset({301, 302, 303, 307, 308})
 
 
 def normalize_url(url: str) -> str:
@@ -50,80 +34,7 @@ def has_same_origin(a: str, b: str) -> bool:
 
     Comparing origins is safer than a string-prefix check: a URL like
     ``http://<host>@evil.example`` or ``http://<host>.evil.example`` shares a
-    prefix with ``http://<host>`` yet resolves to a different origin.
+    prefix with ``http://<host>`` yet resolves to a different origin. Trusting
+    such look-alikes would leak the api-key to an attacker-controlled host.
     """
     return _origin(a) == _origin(b)
-
-
-def _is_public_ip(ip: str) -> bool:
-    address = ipaddress.ip_address(ip)
-    # IPv4-mapped IPv6 addresses (e.g. ``::ffff:169.254.169.254``) must be
-    # judged by the semantics of the underlying IPv4 address. On Python < 3.13
-    # ``is_global`` does not unwrap them automatically.
-    if isinstance(address, ipaddress.IPv6Address) and address.ipv4_mapped:
-        address = address.ipv4_mapped
-    return address.is_global
-
-
-async def _resolve_host(host: str) -> list[str]:
-    loop = asyncio.get_running_loop()
-    try:
-        infos = await loop.getaddrinfo(host, None, type=socket.SOCK_STREAM)
-    except socket.gaierror as e:
-        raise InvalidRequestError(
-            "Can't resolve the host of the file URL"
-        ) from e
-    return [info[4][0] for info in infos]
-
-
-async def validate_public_url(url: str) -> None:
-    """Guard against SSRF by rejecting file URLs that don't point to a
-    publicly routable address.
-
-    An attacker can supply an arbitrary attachment URL (e.g. the cloud
-    metadata endpoint ``http://169.254.169.254``) and force the adapter to
-    fetch it. We only allow ``http``/``https`` URLs whose host resolves
-    exclusively to globally routable IP addresses.
-    """
-    parsed = urlparse(url)
-
-    scheme = parsed.scheme.lower()
-    if scheme not in _ALLOWED_SCHEMES:
-        raise InvalidRequestError(
-            f"Downloading files over the {scheme or 'empty'!r} URL scheme "
-            "is not allowed"
-        )
-
-    host = parsed.hostname
-    if not host:
-        raise InvalidRequestError("The file URL has no host")
-
-    for ip in await _resolve_host(host):
-        if not _is_public_ip(ip):
-            raise InvalidRequestError(
-                "Downloading files from a non-public address is not allowed"
-            )
-
-
-async def download_public_file(url: str) -> bytes:
-    """Download a file from an untrusted URL with SSRF protection.
-
-    Redirects are followed manually so that the target of every hop is
-    validated to be a public address before it is requested. No credentials
-    are ever sent.
-    """
-    async with aiohttp.ClientSession() as session:
-        for _ in range(_MAX_REDIRECTS + 1):
-            await validate_public_url(url)
-
-            async with session.get(url, allow_redirects=False) as response:
-                if response.status in _REDIRECT_STATUSES and (
-                    location := response.headers.get("Location")
-                ):
-                    url = urljoin(url, location)
-                    continue
-
-                response.raise_for_status()
-                return await response.read()
-
-    raise InvalidRequestError("The file URL has too many redirects")

--- a/aidial_adapter_dial/utils/url.py
+++ b/aidial_adapter_dial/utils/url.py
@@ -1,4 +1,22 @@
-from urllib.parse import urlparse, urlunparse
+import asyncio
+import ipaddress
+import socket
+from urllib.parse import urljoin, urlparse, urlunparse
+
+import aiohttp
+from aidial_sdk.exceptions import InvalidRequestError
+
+_DEFAULT_PORTS = {"http": 80, "https": 443}
+
+# Only regular web schemes are allowed. Everything else (e.g. ``file``,
+# ``ftp``, ``gopher``) could be abused to reach local files or internal
+# services.
+_ALLOWED_SCHEMES = frozenset({"http", "https"})
+
+# Redirects are followed manually so that every hop can be re-validated
+# against SSRF, otherwise a public URL could redirect to an internal address.
+_MAX_REDIRECTS = 5
+_REDIRECT_STATUSES = frozenset({301, 302, 303, 307, 308})
 
 
 def normalize_url(url: str) -> str:
@@ -15,3 +33,97 @@ def normalize_url(url: str) -> str:
         netloc = hostname
 
     return urlunparse(parsed._replace(netloc=netloc))
+
+
+def _origin(url: str) -> tuple[str, str, int | None]:
+    parsed = urlparse(url)
+    scheme = parsed.scheme.lower()
+    return (
+        scheme,
+        (parsed.hostname or "").rstrip(".").lower(),
+        parsed.port or _DEFAULT_PORTS.get(scheme),
+    )
+
+
+def has_same_origin(a: str, b: str) -> bool:
+    """Whether two URLs share the same origin (scheme, host and port).
+
+    Comparing origins is safer than a string-prefix check: a URL like
+    ``http://<host>@evil.example`` or ``http://<host>.evil.example`` shares a
+    prefix with ``http://<host>`` yet resolves to a different origin.
+    """
+    return _origin(a) == _origin(b)
+
+
+def _is_public_ip(ip: str) -> bool:
+    address = ipaddress.ip_address(ip)
+    # IPv4-mapped IPv6 addresses (e.g. ``::ffff:169.254.169.254``) must be
+    # judged by the semantics of the underlying IPv4 address. On Python < 3.13
+    # ``is_global`` does not unwrap them automatically.
+    if isinstance(address, ipaddress.IPv6Address) and address.ipv4_mapped:
+        address = address.ipv4_mapped
+    return address.is_global
+
+
+async def _resolve_host(host: str) -> list[str]:
+    loop = asyncio.get_running_loop()
+    try:
+        infos = await loop.getaddrinfo(host, None, type=socket.SOCK_STREAM)
+    except socket.gaierror as e:
+        raise InvalidRequestError(
+            "Can't resolve the host of the file URL"
+        ) from e
+    return [info[4][0] for info in infos]
+
+
+async def validate_public_url(url: str) -> None:
+    """Guard against SSRF by rejecting file URLs that don't point to a
+    publicly routable address.
+
+    An attacker can supply an arbitrary attachment URL (e.g. the cloud
+    metadata endpoint ``http://169.254.169.254``) and force the adapter to
+    fetch it. We only allow ``http``/``https`` URLs whose host resolves
+    exclusively to globally routable IP addresses.
+    """
+    parsed = urlparse(url)
+
+    scheme = parsed.scheme.lower()
+    if scheme not in _ALLOWED_SCHEMES:
+        raise InvalidRequestError(
+            f"Downloading files over the {scheme or 'empty'!r} URL scheme "
+            "is not allowed"
+        )
+
+    host = parsed.hostname
+    if not host:
+        raise InvalidRequestError("The file URL has no host")
+
+    for ip in await _resolve_host(host):
+        if not _is_public_ip(ip):
+            raise InvalidRequestError(
+                "Downloading files from a non-public address is not allowed"
+            )
+
+
+async def download_public_file(url: str) -> bytes:
+    """Download a file from an untrusted URL with SSRF protection.
+
+    Redirects are followed manually so that the target of every hop is
+    validated to be a public address before it is requested. No credentials
+    are ever sent.
+    """
+    async with aiohttp.ClientSession() as session:
+        for _ in range(_MAX_REDIRECTS + 1):
+            await validate_public_url(url)
+
+            async with session.get(url, allow_redirects=False) as response:
+                if response.status in _REDIRECT_STATUSES and (
+                    location := response.headers.get("Location")
+                ):
+                    url = urljoin(url, location)
+                    continue
+
+                response.raise_for_status()
+                return await response.read()
+
+    raise InvalidRequestError("The file URL has too many redirects")

--- a/tests/test_ssrf.py
+++ b/tests/test_ssrf.py
@@ -1,25 +1,12 @@
 import pytest
-from aidial_sdk.exceptions import InvalidRequestError
 
-from aidial_adapter_dial.utils import url as url_module
+from aidial_adapter_dial.utils import storage as storage_module
 from aidial_adapter_dial.utils.storage import FileStorage
-from aidial_adapter_dial.utils.url import (
-    download_public_file,
-    has_same_origin,
-    validate_public_url,
-)
+from aidial_adapter_dial.utils.url import has_same_origin
 
 
 class _FakeResponse:
-    def __init__(
-        self,
-        *,
-        status: int = 200,
-        headers: dict[str, str] | None = None,
-        body: bytes = b"",
-    ):
-        self.status = status
-        self.headers = headers or {}
+    def __init__(self, body: bytes = b""):
         self._body = body
 
     async def __aenter__(self) -> "_FakeResponse":
@@ -29,19 +16,16 @@ class _FakeResponse:
         return False
 
     def raise_for_status(self) -> None:
-        if self.status >= 400:
-            raise RuntimeError(f"unexpected status {self.status}")
+        pass
 
     async def read(self) -> bytes:
         return self._body
 
 
 class _FakeSession:
-    """Minimal aiohttp.ClientSession stand-in that serves canned responses
-    keyed by URL and records the requests it received."""
+    """Minimal aiohttp.ClientSession stand-in that records requests."""
 
-    def __init__(self, routes: dict[str, _FakeResponse], calls: list[dict]):
-        self._routes = routes
+    def __init__(self, calls: list[dict]):
         self._calls = calls
 
     async def __aenter__(self) -> "_FakeSession":
@@ -52,73 +36,18 @@ class _FakeSession:
 
     def get(self, url: str, **kwargs) -> _FakeResponse:
         self._calls.append({"url": url, **kwargs})
-        return self._routes[url]
+        return _FakeResponse(b"payload")
 
 
 @pytest.fixture
-def fake_http(monkeypatch):
+def http_calls(monkeypatch):
     calls: list[dict] = []
-    routes: dict[str, _FakeResponse] = {}
-
-    def install(new_routes: dict[str, _FakeResponse]) -> list[dict]:
-        routes.update(new_routes)
-        monkeypatch.setattr(
-            url_module.aiohttp,
-            "ClientSession",
-            lambda *a, **k: _FakeSession(routes, calls),
-        )
-        return calls
-
-    return install
-
-
-@pytest.mark.parametrize(
-    "url",
-    [
-        # Cloud metadata endpoint.
-        "http://169.254.169.254/metadata/v1/instanceinfo",
-        "http://127.0.0.1/",
-        "http://localhost/secret",
-        "http://10.0.0.1/",
-        "http://192.168.1.1/",
-        "http://172.16.0.1/",
-        "http://0.0.0.0/",
-        "https://[::1]/",
-        # IPv4-mapped IPv6 form of the metadata endpoint.
-        "http://[::ffff:169.254.169.254]/",
-        # Decimal-encoded 127.0.0.1.
-        "http://2130706433/",
-    ],
-)
-async def test_rejects_non_public_address(url: str):
-    with pytest.raises(InvalidRequestError, match="non-public address"):
-        await validate_public_url(url)
-
-
-@pytest.mark.parametrize(
-    "url",
-    [
-        "file:///etc/passwd",
-        "ftp://8.8.8.8/",
-        "gopher://8.8.8.8/",
-        "//8.8.8.8/no-scheme",
-    ],
-)
-async def test_rejects_disallowed_scheme(url: str):
-    with pytest.raises(InvalidRequestError, match="is not allowed"):
-        await validate_public_url(url)
-
-
-@pytest.mark.parametrize(
-    "url",
-    [
-        "http://8.8.8.8/file.txt",
-        "https://1.1.1.1/file.txt",
-        "https://[2606:4700:4700::1111]/file.txt",
-    ],
-)
-async def test_allows_public_address(url: str):
-    await validate_public_url(url)
+    monkeypatch.setattr(
+        storage_module.aiohttp,
+        "ClientSession",
+        lambda *a, **k: _FakeSession(calls),
+    )
+    return calls
 
 
 @pytest.mark.parametrize(
@@ -152,73 +81,36 @@ def test_has_same_origin_false(a: str, b: str):
     assert not has_same_origin(a, b)
 
 
-async def test_download_public_file_follows_public_redirect(fake_http):
-    fake_http(
-        {
-            "http://8.8.8.8/a": _FakeResponse(
-                status=302, headers={"Location": "http://8.8.8.8/b"}
-            ),
-            "http://8.8.8.8/b": _FakeResponse(body=b"payload"),
-        }
+async def test_download_sends_api_key_to_dial_origin(http_calls):
+    storage = FileStorage(dial_url="http://dial-core", api_key="secret")
+
+    content = await storage.download(
+        "files/bucket/doc.txt",
+        session=None,  # type: ignore[arg-type]
     )
 
-    assert await download_public_file("http://8.8.8.8/a") == b"payload"
-
-
-async def test_download_public_file_rejects_redirect_into_internal(fake_http):
-    fake_http(
-        {
-            "http://8.8.8.8/a": _FakeResponse(
-                status=302, headers={"Location": "http://169.254.169.254/"}
-            ),
-        }
-    )
-
-    with pytest.raises(InvalidRequestError, match="non-public address"):
-        await download_public_file("http://8.8.8.8/a")
-
-
-async def test_download_public_file_rejects_redirect_loop(fake_http):
-    fake_http(
-        {
-            "http://8.8.8.8/a": _FakeResponse(
-                status=302, headers={"Location": "http://8.8.8.8/a"}
-            ),
-        }
-    )
-
-    with pytest.raises(InvalidRequestError, match="too many redirects"):
-        await download_public_file("http://8.8.8.8/a")
-
-
-async def test_download_public_file_sends_no_credentials(fake_http):
-    calls = fake_http(
-        {"http://8.8.8.8/file.txt": _FakeResponse(body=b"payload")}
-    )
-
-    assert await download_public_file("http://8.8.8.8/file.txt") == b"payload"
-
-    assert len(calls) == 1
-    headers = {k.lower() for k in (calls[0].get("headers") or {})}
-    assert "api-key" not in headers
-    assert "authorization" not in headers
+    assert content == b"payload"
+    assert len(http_calls) == 1
+    assert http_calls[0]["url"] == "http://dial-core/v1/files/bucket/doc.txt"
+    assert http_calls[0]["headers"]["api-key"] == "secret"
 
 
 @pytest.mark.parametrize(
     "link",
     [
-        # userinfo trick: prefix matches the trusted base URL but the real
-        # host is the cloud metadata endpoint.
+        # userinfo trick: prefix matches the DIAL base URL but the real host
+        # is the cloud metadata endpoint.
         "http://dial-core@169.254.169.254/v1/files/bucket/secret",
-        # decimal-encoded loopback whose host differs from the base URL.
-        "http://dial-core@2130706433/v1/files/bucket/secret",
+        # look-alike host that merely starts with the base URL string.
+        "http://dial-core.attacker.example/v1/files/bucket/secret",
     ],
 )
-async def test_prefix_lookalike_is_rejected(link: str):
+async def test_download_rejects_prefix_lookalikes(http_calls, link: str):
     storage = FileStorage(dial_url="http://dial-core", api_key="secret")
 
-    # A prefix look-alike merely starts with the base URL string but its real
-    # host differs, so it is not recognised as a genuine DIAL URL. It is
-    # rejected before any request is made and the api-key is never sent.
+    # A prefix look-alike is not the DIAL origin, so it is rejected before any
+    # request is made and the api-key is never sent.
     with pytest.raises(ValueError, match="isn't DIAL url"):
         await storage.download(link, session=None)  # type: ignore[arg-type]
+
+    assert http_calls == []

--- a/tests/test_ssrf.py
+++ b/tests/test_ssrf.py
@@ -1,0 +1,224 @@
+import pytest
+from aidial_sdk.exceptions import InvalidRequestError
+
+from aidial_adapter_dial.utils import url as url_module
+from aidial_adapter_dial.utils.storage import FileStorage
+from aidial_adapter_dial.utils.url import (
+    download_public_file,
+    has_same_origin,
+    validate_public_url,
+)
+
+
+class _FakeResponse:
+    def __init__(
+        self,
+        *,
+        status: int = 200,
+        headers: dict[str, str] | None = None,
+        body: bytes = b"",
+    ):
+        self.status = status
+        self.headers = headers or {}
+        self._body = body
+
+    async def __aenter__(self) -> "_FakeResponse":
+        return self
+
+    async def __aexit__(self, *exc) -> bool:
+        return False
+
+    def raise_for_status(self) -> None:
+        if self.status >= 400:
+            raise RuntimeError(f"unexpected status {self.status}")
+
+    async def read(self) -> bytes:
+        return self._body
+
+
+class _FakeSession:
+    """Minimal aiohttp.ClientSession stand-in that serves canned responses
+    keyed by URL and records the requests it received."""
+
+    def __init__(self, routes: dict[str, _FakeResponse], calls: list[dict]):
+        self._routes = routes
+        self._calls = calls
+
+    async def __aenter__(self) -> "_FakeSession":
+        return self
+
+    async def __aexit__(self, *exc) -> bool:
+        return False
+
+    def get(self, url: str, **kwargs) -> _FakeResponse:
+        self._calls.append({"url": url, **kwargs})
+        return self._routes[url]
+
+
+@pytest.fixture
+def fake_http(monkeypatch):
+    calls: list[dict] = []
+    routes: dict[str, _FakeResponse] = {}
+
+    def install(new_routes: dict[str, _FakeResponse]) -> list[dict]:
+        routes.update(new_routes)
+        monkeypatch.setattr(
+            url_module.aiohttp,
+            "ClientSession",
+            lambda *a, **k: _FakeSession(routes, calls),
+        )
+        return calls
+
+    return install
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        # Cloud metadata endpoint.
+        "http://169.254.169.254/metadata/v1/instanceinfo",
+        "http://127.0.0.1/",
+        "http://localhost/secret",
+        "http://10.0.0.1/",
+        "http://192.168.1.1/",
+        "http://172.16.0.1/",
+        "http://0.0.0.0/",
+        "https://[::1]/",
+        # IPv4-mapped IPv6 form of the metadata endpoint.
+        "http://[::ffff:169.254.169.254]/",
+        # Decimal-encoded 127.0.0.1.
+        "http://2130706433/",
+    ],
+)
+async def test_rejects_non_public_address(url: str):
+    with pytest.raises(InvalidRequestError, match="non-public address"):
+        await validate_public_url(url)
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "file:///etc/passwd",
+        "ftp://8.8.8.8/",
+        "gopher://8.8.8.8/",
+        "//8.8.8.8/no-scheme",
+    ],
+)
+async def test_rejects_disallowed_scheme(url: str):
+    with pytest.raises(InvalidRequestError, match="is not allowed"):
+        await validate_public_url(url)
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "http://8.8.8.8/file.txt",
+        "https://1.1.1.1/file.txt",
+        "https://[2606:4700:4700::1111]/file.txt",
+    ],
+)
+async def test_allows_public_address(url: str):
+    await validate_public_url(url)
+
+
+@pytest.mark.parametrize(
+    ("a", "b"),
+    [
+        ("http://dial-core/v1/files/x", "http://dial-core"),
+        ("http://dial-core:80/v1/files/x", "http://dial-core"),
+        ("https://dial-core:443/v1/files/x", "https://dial-core"),
+        ("http://DIAL-CORE/v1/files/x", "http://dial-core"),
+        ("http://dial-core.:7001/v1", "http://dial-core:7001"),
+    ],
+)
+def test_has_same_origin_true(a: str, b: str):
+    assert has_same_origin(a, b)
+
+
+@pytest.mark.parametrize(
+    ("a", "b"),
+    [
+        # userinfo trick: prefix matches but the real host differs.
+        ("http://dial-core@169.254.169.254/v1", "http://dial-core"),
+        # look-alike domain that merely starts with the base URL string.
+        ("http://dial-core.attacker.example/v1", "http://dial-core"),
+        # different scheme.
+        ("https://dial-core/v1", "http://dial-core"),
+        # different port.
+        ("http://dial-core:7001/v1", "http://dial-core"),
+    ],
+)
+def test_has_same_origin_false(a: str, b: str):
+    assert not has_same_origin(a, b)
+
+
+async def test_download_public_file_follows_public_redirect(fake_http):
+    fake_http(
+        {
+            "http://8.8.8.8/a": _FakeResponse(
+                status=302, headers={"Location": "http://8.8.8.8/b"}
+            ),
+            "http://8.8.8.8/b": _FakeResponse(body=b"payload"),
+        }
+    )
+
+    assert await download_public_file("http://8.8.8.8/a") == b"payload"
+
+
+async def test_download_public_file_rejects_redirect_into_internal(fake_http):
+    fake_http(
+        {
+            "http://8.8.8.8/a": _FakeResponse(
+                status=302, headers={"Location": "http://169.254.169.254/"}
+            ),
+        }
+    )
+
+    with pytest.raises(InvalidRequestError, match="non-public address"):
+        await download_public_file("http://8.8.8.8/a")
+
+
+async def test_download_public_file_rejects_redirect_loop(fake_http):
+    fake_http(
+        {
+            "http://8.8.8.8/a": _FakeResponse(
+                status=302, headers={"Location": "http://8.8.8.8/a"}
+            ),
+        }
+    )
+
+    with pytest.raises(InvalidRequestError, match="too many redirects"):
+        await download_public_file("http://8.8.8.8/a")
+
+
+async def test_download_public_file_sends_no_credentials(fake_http):
+    calls = fake_http(
+        {"http://8.8.8.8/file.txt": _FakeResponse(body=b"payload")}
+    )
+
+    assert await download_public_file("http://8.8.8.8/file.txt") == b"payload"
+
+    assert len(calls) == 1
+    headers = {k.lower() for k in (calls[0].get("headers") or {})}
+    assert "api-key" not in headers
+    assert "authorization" not in headers
+
+
+@pytest.mark.parametrize(
+    "link",
+    [
+        # userinfo trick: prefix matches the trusted base URL but the real
+        # host is the cloud metadata endpoint.
+        "http://dial-core@169.254.169.254/v1/files/bucket/secret",
+        # decimal-encoded loopback whose host differs from the base URL.
+        "http://dial-core@2130706433/v1/files/bucket/secret",
+    ],
+)
+async def test_prefix_lookalike_is_untrusted_and_rejected(link: str):
+    storage = FileStorage(dial_url="http://dial-core", api_key="secret")
+
+    # A non-DIAL origin must be treated as untrusted and SSRF-validated,
+    # so a non-public target is rejected before any request (and the api-key
+    # is never sent).
+    with pytest.raises(InvalidRequestError, match="non-public address"):
+        await storage.download(link, session=None)  # type: ignore[arg-type]

--- a/tests/test_ssrf.py
+++ b/tests/test_ssrf.py
@@ -214,11 +214,11 @@ async def test_download_public_file_sends_no_credentials(fake_http):
         "http://dial-core@2130706433/v1/files/bucket/secret",
     ],
 )
-async def test_prefix_lookalike_is_untrusted_and_rejected(link: str):
+async def test_prefix_lookalike_is_rejected(link: str):
     storage = FileStorage(dial_url="http://dial-core", api_key="secret")
 
-    # A non-DIAL origin must be treated as untrusted and SSRF-validated,
-    # so a non-public target is rejected before any request (and the api-key
-    # is never sent).
-    with pytest.raises(InvalidRequestError, match="non-public address"):
+    # A prefix look-alike merely starts with the base URL string but its real
+    # host differs, so it is not recognised as a genuine DIAL URL. It is
+    # rejected before any request is made and the api-key is never sent.
+    with pytest.raises(ValueError, match="isn't DIAL url"):
         await storage.download(link, session=None)  # type: ignore[arg-type]


### PR DESCRIPTION
## Summary

Files referenced from chat requests (attachment URLs and image/file content parts) are only downloaded server-side when they point to the adapter's own DIAL storage; any other URL is passed through to the remote DIAL untouched. The check that decided "is this a DIAL URL?" (and therefore whether to attach the api-key) was a string-prefix comparison, which is bypassable.

This PR makes that trust decision origin-based:

- Add `has_same_origin(a, b)` in `aidial_adapter_dial/utils/url.py`, comparing origin (scheme, host, port; default ports normalized), not a string prefix.
- `FileStorage.download` now rejects any URL whose origin differs from the configured DIAL URL, so the api-key is only ever sent to the genuine DIAL origin.

Why origin instead of prefix: a URL like `http://<dial_url>@169.254.169.254/...` or `http://<dial_url>.attacker.example/...` "starts with" the base URL string yet resolves to a different, internal host. A prefix check would treat these look-alikes as trusted and leak the api-key to an attacker-controlled host.

The adapter still does not fetch arbitrary public URLs — non-DIAL URLs are left as-is and forwarded to the remote DIAL. `data:`/base64/local decoding paths are unaffected.

## Test plan

New unit tests (`tests/test_ssrf.py`, hermetic — no network):

- `has_same_origin` positive cases (default-port and trailing-dot normalization, case-insensitive host) and negative cases (userinfo `@` trick, look-alike subdomain, differing scheme, differing port).
- `FileStorage.download` sends the api-key only to the DIAL origin.
- `FileStorage.download` rejects prefix look-alikes (`@` userinfo and look-alike subdomain) with an error before any request is made, so the api-key is never sent.